### PR TITLE
README: Fix one missing conversion libaxolotl-c -> libsignal-protocol-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ CMake toolchain files have been included from the following sources:
 * [iOS](https://code.google.com/p/ios-cmake/)
 * [BlackBerry 10](https://github.com/blackberry/OGRE/blob/master/src/CMake/toolchain/blackberry.toolchain.cmake)
 
-# Using libaxolotl-c
+# Using libsignal-protocol-c
 
 ## Library initialization
 


### PR DESCRIPTION
Fix one instance missed during library renaming in commit e8a90def