### PR TITLE
Fix count type to allow overflow check against SIZE_MAX

### DIFF
--- a/src/sender_key_record.c
+++ b/src/sender_key_record.c
@@ -50,7 +50,7 @@ int sender_key_record_serialize(axolotl_buffer **buffer, sender_key_record *reco
     size_t len;
 
     if(record->sender_key_states_head) {
-        unsigned int count;
+        size_t count;
         DL_COUNT(record->sender_key_states_head, cur_node, count);
 
         if(count > SIZE_MAX / sizeof(Textsecure__SenderKeyStateStructure *)) {

--- a/src/sender_key_state.c
+++ b/src/sender_key_state.c
@@ -207,7 +207,7 @@ int sender_key_state_serialize_prepare(sender_key_state *state, Textsecure__Send
 
     /* Sender message keys */
     if(state->message_keys_head) {
-        unsigned int count;
+        size_t count;
         DL_COUNT(state->message_keys_head, cur_node, count);
 
         if(count > SIZE_MAX / sizeof(Textsecure__SenderKeyStateStructure__SenderMessageKey *)) {

--- a/src/session_record.c
+++ b/src/session_record.c
@@ -81,7 +81,7 @@ int session_record_serialize(axolotl_buffer **buffer, const session_record *reco
     }
 
     if(record->previous_states_head) {
-        unsigned int count;
+        size_t count;
         DL_COUNT(record->previous_states_head, cur_node, count);
 
         if(count > SIZE_MAX / sizeof(Textsecure__SessionStructure *)) {

--- a/src/session_state.c
+++ b/src/session_state.c
@@ -287,9 +287,7 @@ int session_state_serialize_prepare(session_state *state, Textsecure__SessionStr
     }
 
     if(state->receiver_chain_head) {
-        size_t i = 0;
-
-        unsigned int count;
+        size_t count, i = 0;
         session_state_receiver_chain *cur_node;
         DL_COUNT(state->receiver_chain_head, cur_node, count);
 
@@ -480,9 +478,7 @@ static int session_state_serialize_prepare_chain_message_keys_list(
         Textsecure__SessionStructure__Chain *chain_structure)
 {
     int result = 0;
-    size_t i = 0;
-    
-    unsigned int count;
+    size_t count, i = 0;
     message_keys_node *cur_node;
     DL_COUNT(message_keys_head, cur_node, count);
 


### PR DESCRIPTION
On systems where sizeof(unsigned int) < sizeof(size_t), the allocation
overflow checks of the following form can never be true:

  unsigned int count;
  DL_COUNT(..., ..., count)

  if (count > SIZE_MAX / sizeof(...)) {
      return AX_ERR_NOMEM;
  }

  buf = malloc(count * sizeof(...));

Fix them by making the counts of type size_t.

Noticed due to [-Wtautological-constant-out-of-range-compare] warnings
emitted by clang 3.8.