### PR TITLE
Dockerized libsignal-protocol-c build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu
+MAINTAINER Stewart Henderson <stewart.henderson@protonmail.com>
+
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test 
+RUN apt-get update
+RUN apt-get -y install gcc-4.9 g++-4.9 cmake build-essential
+
+
+RUN mkdir /development
+RUN mkdir /development/build
+ADD . /development
+RUN cd /development/build \
+	&& cmake -DCMAKE_BUILD_TYPE=Debug .. \
+	&& make


### PR DESCRIPTION
This workflow seeks to add in dockerized builds of the libsignal-protocol-c library.  It presently uses an Ubuntu image with the requirements.  It can be built with the "docker build -t libsignal-protocol-c ." command.  I didn't update the README.md as part of this workflow but can do so if desired.