### PR TITLE
Fix some printf formatting codes for size_t/ssize_t.

### DIFF
--- a/src/curve.c
+++ b/src/curve.c
@@ -41,7 +41,7 @@ int curve_decode_point(ec_public_key **public_key, const uint8_t *key_data, size
     }
 
     if(key_len != DJB_KEY_LEN + 1) {
-        signal_log(global_context, SG_LOG_ERROR, "Invalid key length: %d", key_len);
+        signal_log(global_context, SG_LOG_ERROR, "Invalid key length: %zu", key_len);
         return SG_ERR_INVALID_KEY;
     }
 
@@ -143,7 +143,7 @@ int curve_decode_private_point(ec_private_key **private_key, const uint8_t *key_
     ec_private_key *key = 0;
 
     if(key_len != DJB_KEY_LEN) {
-        signal_log(global_context, SG_LOG_ERROR, "Invalid key length: %d", key_len);
+        signal_log(global_context, SG_LOG_ERROR, "Invalid key length: %zu", key_len);
         return SG_ERR_INVALID_KEY;
     }
 

--- a/src/hkdf.c
+++ b/src/hkdf.c
@@ -214,7 +214,7 @@ ssize_t hkdf_derive_secrets(hkdf_context *context,
 
     prk_len = hkdf_extract(context, &prk, salt, salt_len, input_key_material, input_key_material_len);
     if(prk_len < 0) {
-        signal_log(context->global_context, SG_LOG_ERROR, "hkdf_extract error: %d", prk_len);
+        signal_log(context->global_context, SG_LOG_ERROR, "hkdf_extract error: %zd", prk_len);
         return prk_len;
     }
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -273,7 +273,7 @@ int key_exchange_message_deserialize(key_exchange_message **message, const uint8
     }
 
     if(message_structure->has_basekeysignature && message_structure->basekeysignature.len != CURVE_SIGNATURE_LEN) {
-        signal_log(global_context, SG_LOG_WARNING, "Invalid base key signature length: %d", message_structure->basekeysignature.len);
+        signal_log(global_context, SG_LOG_WARNING, "Invalid base key signature length: %zu", message_structure->basekeysignature.len);
         result = SG_ERR_INVALID_MESSAGE;
         goto complete;
     }
@@ -770,7 +770,7 @@ int signal_message_verify_mac(signal_message *message,
     our_mac_data = signal_buffer_data(our_mac_buffer);
     our_mac_len = signal_buffer_len(our_mac_buffer);
     if(our_mac_len != their_mac_len) {
-        signal_log(global_context, SG_LOG_WARNING, "MAC length mismatch: %d != %d", our_mac_len, their_mac_len);
+        signal_log(global_context, SG_LOG_WARNING, "MAC length mismatch: %zu != %zu", our_mac_len, their_mac_len);
         result = SG_ERR_UNKNOWN;
         goto complete;
     }

--- a/src/ratchet.c
+++ b/src/ratchet.c
@@ -199,7 +199,7 @@ int ratchet_chain_key_get_message_keys(ratchet_chain_key *chain_key, ratchet_mes
 
     if(key_material_data_len != RATCHET_CIPHER_KEY_LENGTH + RATCHET_MAC_KEY_LENGTH + RATCHET_IV_LENGTH) {
         signal_log(chain_key->global_context, SG_LOG_WARNING,
-                "key_material_data length mismatch: %d != %d",
+                "key_material_data length mismatch: %zu != %d",
                 key_material_data_len, (RATCHET_CIPHER_KEY_LENGTH + RATCHET_MAC_KEY_LENGTH + RATCHET_IV_LENGTH));
         result = SG_ERR_UNKNOWN;
         goto complete;


### PR DESCRIPTION
This commit switches to using "%zu" and "%zd" for printing size_t and ssize_t,
respectively. These format codes are more portable than "%u" or "%d". For
example, on x86_64 size_ts and ssize_ts are 64-bit values, while ints are 32-bit
values. In practice, this does not cause problems in the x86_64 System V ABI
because 32-bit values are naturally extended in this scenario, but on other
platforms it can cause stack corruption.

----

If you're happy to accept this, I believe I need to sign a CLA, but it's not clear to me where to get this from. Are you able to point me in the right direction? Thanks.

Also, I inadvertently picked this up after slapping `__attribute__((format(printf, 3, 4)))` on the `signal_log` declaration. I assumed you don't want GNU-isms like this in the code base so I didn't commit this as well, but please let me know if you'd like me to include that change as well.