### PR TITLE
Prevent possible null dereference of signal_context->log

### DIFF
--- a/src/signal_protocol.c
+++ b/src/signal_protocol.c
@@ -447,7 +447,7 @@ void signal_log(signal_context *context, int level, const char *format, ...)
 {
     char buf[256];
     int n;
-    if(context->log) {
+    if(context && context->log) {
         va_list args;
         va_start(args, format);
         n = vsnprintf(buf, sizeof(buf), format, args);


### PR DESCRIPTION
If for whatever reason you don't pass a context (or it's null somehow) to `int curve_decode_point(ec_public_key **public_key, const uint8_t *key_data, size_t key_len, signal_context *global_context);` and other related functions, it will dereference a null pointer when checking for `context->log` within `signal_log`. Passing a context isn't strictly necessary for the purpose of `curve_decode_point` anyway because it is only to support log functions.
