### PR TITLE
README: add missing step to setting up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Items marked with *1 are required for tests, with *2 are additionally required f
 
     $ cd /path/to/libsignal-protocol-c/build
     $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=1 ..
+    $ cd tests
+    $ make
+    $ cd ..
     $ ctest
 
 ### Creating the code coverage report


### PR DESCRIPTION
I'm sure most people figure this out really fast, but I thought we might add these steps to the README for completeness. 