### PR TITLE
Fix potential NULL dereference when debugging reference counts.

### DIFF
--- a/src/signal_protocol.c
+++ b/src/signal_protocol.c
@@ -69,6 +69,9 @@ void signal_type_unref(signal_type_base *instance)
 #ifdef DEBUG_REFCOUNT
 int signal_type_ref_count(signal_type_base *instance)
 {
+    if(!instance) {
+        return 0;
+    }
     return instance->ref_count;
 }
 #endif


### PR DESCRIPTION
With reference count debugging enabled (`DEBUG_REFCOUNT`), it is possible
to trigger a call to `signal_type_ref_count` with a `NULL` argument. For
example, when `session_record_archive_current_state` is invoked and its
call to `session_state_create` fails with `SG_ERR_NOMEM`. During reference
count decrement, `signal_type_unref` guards against the pointer being
`NULL`, but `signal_type_ref_count` does not. This commit fixes this issue
by refactoring the latter.
