### PR TITLE
Abort pre key processing on failure to archive current state.

### DIFF
--- a/src/session_builder.c
+++ b/src/session_builder.c
@@ -145,7 +145,10 @@ static int session_builder_process_pre_key_signal_message_v3(session_builder *bu
     }
 
     if(!session_record_is_fresh(record)) {
-        session_record_archive_current_state(record);
+        result = session_record_archive_current_state(record);
+        if(result < 0) {
+            goto complete;
+        }
     }
 
     state = session_record_get_state(record);


### PR DESCRIPTION
The function `session_builder_process_pre_key_signal_message_v3` did not
check the result when archiving the current state due to a stale record.
A consequence of this was that processing would continue in the face of
this archiving failing. The archiving operation can only fail due to
heap exhaustion, so it is likely the following operations would also
fail for the same reason.

This commit modifies the function to abort as soon as an error is
detected. IMHO, it was not possible for an attacker to leverage the
previous control flow to their advantage without having a degree of
observability which would provide them with other, simpler attack
vectors. However, it seems safer to abort as soon as we can detect an
error in this scenario.

----

I only have a partial understanding of the code in this area, and it's possible I've misconstrued something. Perhaps there's another, external reason why this failure is not possible. If I'm mistaken, apologies for taking up your time.