### PR TITLE
Abort session builder operations on failure to archive current state.

### DIFF
--- a/src/session_builder.c
+++ b/src/session_builder.c
@@ -296,7 +296,10 @@ int session_builder_process_pre_key_bundle(session_builder *builder, session_pre
     }
 
     if(!session_record_is_fresh(record)) {
-        session_record_archive_current_state(record);
+        result = session_record_archive_current_state(record);
+        if(result < 0) {
+            goto complete;
+        }
     }
 
     state = session_record_get_state(record);
@@ -473,7 +476,10 @@ static int session_builder_process_initiate(session_builder *builder, key_exchan
     }
 
     if(!session_record_is_fresh(record)) {
-        session_record_archive_current_state(record);
+        result = session_record_archive_current_state(record);
+        if(result < 0) {
+            goto complete;
+        }
     }
 
     state = session_record_get_state(record);
@@ -585,7 +591,10 @@ static int session_builder_process_response(session_builder *builder, key_exchan
     }
 
     if(!session_record_is_fresh(record)) {
-        session_record_archive_current_state(record);
+        result = session_record_archive_current_state(record);
+        if(result < 0) {
+            goto complete;
+        }
     }
 
     state = session_record_get_state(record);


### PR DESCRIPTION
Similarly to `session_builder_process_pre_key_signal_message_v3` that was
not checking for a failure to archive the current state prior to
a1248b27ac9cc89d6f2fe90a4dd766bfa253a608, other session builder
functions were also not anticipating this scenario. Following this
change, all session builder functions check for this failure and abort
their operation if it occurs.

----

A couple of the pull requests I've submitted recently were formed by putting [`warn_unused_result`](
https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-g_t_0040code_007bwarn_005funused_005fresult_007d-function-attribute-3304) on some interesting looking functions, observing compilation warnings and then exploring the control flow around the site of the warning. I know this library needs to build in a wide variety of environments, not all of which have support for non-standard features like this, but I wonder if it would be worth enabling these when they are available. For example, like is [currently done in utarray.h](https://github.com/WhisperSystems/libsignal-protocol-c/blob/master/src/utarray.h#L31-L35). Personally I find many modern compiler bells and whistles like these an invaluable linter, but I know they are not universally beloved. What are your thoughts? Please let me know if there's a more appropriate forum in which to have this discussion. Thanks as always :)