### PR TITLE
fix missing result check in device_consistency_message_create_from_se…

### DIFF
--- a/src/device_consistency.c
+++ b/src/device_consistency.c
@@ -362,7 +362,7 @@ int device_consistency_message_create_from_serialized(device_consistency_message
     /* Assign the message fields */
     result_message->generation = message_structure->generation;
 
-    device_consistency_signature_create(&result_message->signature,
+    result = device_consistency_signature_create(&result_message->signature,
             message_structure->signature.data, message_structure->signature.len,
             signal_buffer_data(vrf_output_buffer), signal_buffer_len(vrf_output_buffer));
     if(result < 0) {


### PR DESCRIPTION
…rialized

It was possible for the call to device_consistency_signature_create to fail with
SG_ERR_NOMEM and for this failure to go unnoticed.

----

This looks like a simple typo to me, given the following check of `result`. Like a couple of my previous commits, I inadvertently noticed this because I'd sprinkled some compiler annotations on the code; in this case, `__attribute__((warn_unused_result))` on `device_consistency_signature_create`. I realise maintaining portability is very important to Whisper and I've asked about this previously, but I wanted to poll folks again to see what your current thinking is with respect to adding some of these annotations, maybe hidden by some `#ifdef` guards. Personally, I find them an indispensable aid for catching my own typos. As always, thanks for your excellent work with Signal and friends :)