### PR TITLE
Link with math library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(signal-protocol-c
 	$<TARGET_OBJECTS:protobuf-c>
 )
 
+target_link_libraries(signal-protocol-c m)
+
 INSTALL(
 	FILES
 	signal_protocol.h


### PR DESCRIPTION
This patch explicitly links signal-protocol-c with the Math library.
hkdf_expand() in src/hkdf.c:109 makes use of 'ceil'.

On some systems without explicitly stating the math library it will not
build.

Solves https://github.com/WhisperSystems/libsignal-protocol-c/issues/57