### PR TITLE
Fix clang warning

### DIFF
--- a/src/device_consistency.c
+++ b/src/device_consistency.c
@@ -650,7 +650,7 @@ int device_consistency_signature_list_sort_comparator(const void *a, const void 
         result = memcmp(signal_buffer_data(buf1), signal_buffer_data(buf2), len1);
     }
     else {
-        result = len1 - len2;
+        result = (int)(len1 - len2);
     }
 
     return result;


### PR DESCRIPTION
It fixes on Mac OS X 

```
[ 98%] Building C object src/CMakeFiles/signal-protocol-c.dir/device_consistency.c.o
/Users/taurus/devel/libsignal-protocol-c/src/device_consistency.c:653:23: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
        result = len1 - len2;
               ~ ~~~~~^~~~~~
1 warning generated.
```