### PR TITLE
Add custom curve25519 implementation usage

### DIFF
--- a/src/curve.h
+++ b/src/curve.h
@@ -57,7 +57,7 @@ ec_private_key *ec_key_pair_get_private(const ec_key_pair *key_pair);
 void ec_key_pair_destroy(signal_type_base *type);
 
 int curve_generate_private_key(signal_context *context, ec_private_key **private_key);
-int curve_generate_public_key(ec_public_key **public_key, const ec_private_key *private_key);
+int curve_generate_public_key(signal_context *context, ec_public_key **public_key, const ec_private_key *private_key);
 
 /**
  * Generates a Curve25519 keypair.
@@ -123,16 +123,18 @@ void ec_public_key_list_free(ec_public_key_list *list);
 /**
  * Calculates an ECDH agreement.
  *
+ * @param context The valid context
  * @param shared_key_data Set to a 32-byte shared secret on success.
  * @param public_key The Curve25519 (typically remote party's) public key.
  * @param private_key The Curve25519 (typically yours) private key.
  * @return 0 on success, negative on failure
  */
-int curve_calculate_agreement(uint8_t **shared_key_data, const ec_public_key *public_key, const ec_private_key *private_key);
+int curve_calculate_agreement(signal_context *context, uint8_t **shared_key_data, const ec_public_key *public_key, const ec_private_key *private_key);
 
 /**
  * Verify a Curve25519 signature.
  *
+ * @param context The valid context
  * @param signing_key The Curve25519 public key the signature belongs to.
  * @param message_data The message that was signed.
  * @param message_len The length of the message that was signed.
@@ -140,7 +142,8 @@ int curve_calculate_agreement(uint8_t **shared_key_data, const ec_public_key *pu
  * @param signature_len The length of the signature to verify.
  * @return 1 if valid, 0 if invalid, negative on failure
  */
-int curve_verify_signature(const ec_public_key *signing_key,
+int curve_verify_signature(signal_context *context,
+        const ec_public_key *signing_key,
         const uint8_t *message_data, size_t message_len,
         const uint8_t *signature_data, size_t signature_len);
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -1138,7 +1138,7 @@ int sender_key_message_verify_signature(sender_key_message *message, ec_public_k
     data = signal_buffer_data(message->base_message.serialized);
     data_len = signal_buffer_len(message->base_message.serialized) - SIGNATURE_LENGTH;
 
-    result = curve_verify_signature(signature_key, data, data_len, data + data_len, SIGNATURE_LENGTH);
+    result = curve_verify_signature(message->base_message.global_context, signature_key, data, data_len, data + data_len, SIGNATURE_LENGTH);
 
     if(result == 0) {
         signal_log(message->base_message.global_context, SG_LOG_ERROR, "Invalid signature!");

--- a/src/ratchet.c
+++ b/src/ratchet.c
@@ -315,7 +315,7 @@ int ratchet_root_key_create_chain(ratchet_root_key *root_key,
         return SG_ERR_INVAL;
     }
 
-    result = curve_calculate_agreement(&shared_secret, their_ratchet_key, our_ratchet_key_private);
+    result = curve_calculate_agreement(root_key->global_context, &shared_secret, their_ratchet_key, our_ratchet_key_private);
     if(result < 0) {
         signal_log(root_key->global_context, SG_LOG_WARNING, "curve_calculate_agreement failed");
         goto complete;
@@ -1007,7 +1007,7 @@ int ratcheting_session_alice_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_signed_pre_key, parameters->our_identity_key->private_key);
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1021,7 +1021,7 @@ int ratcheting_session_alice_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_identity_key, ec_key_pair_get_private(parameters->our_base_key));
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1035,7 +1035,7 @@ int ratcheting_session_alice_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_signed_pre_key, ec_key_pair_get_private(parameters->our_base_key));
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1050,7 +1050,7 @@ int ratcheting_session_alice_initialize(
     }
 
     if(parameters->their_one_time_pre_key) {
-        agreement_len = curve_calculate_agreement(&agreement,
+        agreement_len = curve_calculate_agreement(global_context, &agreement,
                 parameters->their_one_time_pre_key, ec_key_pair_get_private(parameters->our_base_key));
         if(agreement_len < 0) {
             result = agreement_len;
@@ -1148,7 +1148,7 @@ int ratcheting_session_bob_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_identity_key, ec_key_pair_get_private(parameters->our_signed_pre_key));
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1162,7 +1162,7 @@ int ratcheting_session_bob_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_base_key, parameters->our_identity_key->private_key);
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1176,7 +1176,7 @@ int ratcheting_session_bob_initialize(
         goto complete;
     }
 
-    agreement_len = curve_calculate_agreement(&agreement,
+    agreement_len = curve_calculate_agreement(global_context, &agreement,
             parameters->their_base_key, ec_key_pair_get_private(parameters->our_signed_pre_key));
     if(agreement_len < 0) {
         result = agreement_len;
@@ -1191,7 +1191,7 @@ int ratcheting_session_bob_initialize(
     }
 
     if(parameters->our_one_time_pre_key) {
-        agreement_len = curve_calculate_agreement(&agreement,
+        agreement_len = curve_calculate_agreement(global_context, &agreement,
                 parameters->their_base_key, ec_key_pair_get_private(parameters->our_one_time_pre_key));
         if(agreement_len < 0) {
             result = agreement_len;

--- a/src/session_builder.c
+++ b/src/session_builder.c
@@ -234,7 +234,8 @@ int session_builder_process_pre_key_bundle(session_builder *builder, session_pre
             goto complete;
         }
 
-        result = curve_verify_signature(identity_key,
+        result = curve_verify_signature(builder->global_context,
+                identity_key,
                 signal_buffer_data(serialized_signed_pre_key),
                 signal_buffer_len(serialized_signed_pre_key),
                 signal_buffer_data(signature),

--- a/src/signal_protocol.h
+++ b/src/signal_protocol.h
@@ -406,6 +406,60 @@ typedef struct signal_crypto_provider {
             const uint8_t *ciphertext, size_t ciphertext_len,
             void *user_data);
 
+    /**
+     * Callback for calculation of curve25519
+     *
+     * This is optional function callback, if not set embedded implementation of curve25519-donna will be
+     * used
+     *
+     * @param output The buffer where the calculated output will be filled (must be 32 bytes)
+     * @param input1 The first input buffer for cuver25519 calculation (must be 32 bytes)
+     * @param input2 The second input buffer for cuver25519 calculation (must be 32 bytes)
+     * @param user_data The user data
+     * @return 0 on success, negative on failure
+     */
+    int (*curve25519_func)(uint8_t *output,
+            const uint8_t *input1,
+            const uint8_t *input2,
+            void *user_data);
+
+    /**
+     * Callback for signature calculation based on curve25519
+     *
+     * This is optional function callback, if not set embedded implementation of curve25519-donna/ed25519
+     * will be used
+     *
+     * @param signature_out The buffer where the calculated signature will be filled (must be 64 bytes)
+     * @param curve25519_privkey The private key (must be 32 bytes)
+     * @param msg The message buffer, which will be signed (must be <= 256 bytes)
+     * @param msg_len The message buffer length
+     * @param random The random buffer (must be 64 bytes)
+     * @param user_data The user data
+     * @return 0 on success, negative on failure
+     */
+    int (*curve25519_sign_func)(uint8_t *signature_out,
+                     const uint8_t *curve25519_privkey,
+                     const uint8_t *msg, const unsigned long msg_len,
+                     const uint8_t *random, void *user_data);
+
+    /**
+     * Callback for signature verification based on curve25519
+     *
+     * This is optional function callback, if not set embedded implementation of curve25519-donna/ed25519
+     * will be used
+     *
+     * @param signature The signature buffer (must be 64 bytes)
+     * @param curve25519_pubkey The public key (must be 32 bytes)
+     * @param msg The message buffer, which will be signed (must be <= 256 bytes)
+     * @param msg_len The message buffer length
+     * @param user_data The user data
+     * @return 0 on success, negative on failure
+     */
+    int (*curve25519_verify_func)(const uint8_t *signature,
+                      const uint8_t *curve25519_pubkey,
+                      const uint8_t *msg, const unsigned long msg_len,
+                      void *user_data);
+
     /** User data pointer */
     void *user_data;
 } signal_crypto_provider;

--- a/tests/test_curve25519.c
+++ b/tests/test_curve25519.c
@@ -108,12 +108,12 @@ START_TEST(test_curve25519_agreement)
     ck_assert_ptr_ne(bob_private_key, 0);
 
     /* Calculate key agreement one */
-    result = curve_calculate_agreement(&shared_one, alice_public_key, bob_private_key);
+    result = curve_calculate_agreement(global_context, &shared_one, alice_public_key, bob_private_key);
     ck_assert_int_eq(result, 32);
     ck_assert_ptr_ne(shared_one, 0);
 
     /* Calculate key agreement two */
-    result = curve_calculate_agreement(&shared_two, bob_public_key, alice_private_key);
+    result = curve_calculate_agreement(global_context ,&shared_two, bob_public_key, alice_private_key);
     ck_assert_int_eq(result, 32);
     ck_assert_ptr_ne(shared_two, 0);
 
@@ -168,7 +168,7 @@ START_TEST(test_curve25519_generate_public)
     ck_assert_ptr_ne(alice_expected_public_key, 0);
 
     /* Generate Alice's actual public key */
-    result = curve_generate_public_key(&alice_public_key, alice_private_key);
+    result = curve_generate_public_key(global_context, &alice_public_key, alice_private_key);
     ck_assert_int_eq(result, 0);
     ck_assert_ptr_ne(alice_public_key, 0);
 
@@ -218,12 +218,12 @@ START_TEST(test_curve25519_random_agreements)
         ck_assert_ptr_ne(bob_private_key, 0);
 
         /* Calculate Alice's key agreement */
-        result = curve_calculate_agreement(&shared_alice, bob_public_key, alice_private_key);
+        result = curve_calculate_agreement(global_context ,&shared_alice, bob_public_key, alice_private_key);
         ck_assert_int_eq(result, 32);
         ck_assert_ptr_ne(shared_alice, 0);
 
         /* Calculate Bob's key agreement */
-        result = curve_calculate_agreement(&shared_bob, alice_public_key, bob_private_key);
+        result = curve_calculate_agreement(global_context ,&shared_bob, alice_public_key, bob_private_key);
         ck_assert_int_eq(result, 32);
         ck_assert_ptr_ne(shared_bob, 0);
 
@@ -302,7 +302,7 @@ START_TEST(test_curve25519_signature)
     ck_assert_int_eq(result, 0);
     ck_assert_ptr_ne(alice_ephemeral, 0);
 
-    result = curve_verify_signature(alice_public_key,
+    result = curve_verify_signature(global_context, alice_public_key,
             aliceEphemeralPublic, sizeof(aliceEphemeralPublic),
             aliceSignature, sizeof(aliceSignature));
     ck_assert_msg(result == 1, "signature verification failed");
@@ -314,7 +314,7 @@ START_TEST(test_curve25519_signature)
         memcpy(modifiedSignature, aliceSignature, sizeof(aliceSignature));
         modifiedSignature[i] ^= 0x01;
 
-        result = curve_verify_signature(alice_public_key,
+        result = curve_verify_signature(global_context, alice_public_key,
                 aliceEphemeralPublic, sizeof(aliceEphemeralPublic),
                 modifiedSignature, sizeof(modifiedSignature));
         ck_assert_msg(result != 1, "signature verification succeeded");
@@ -347,13 +347,13 @@ START_TEST(test_curve25519_large_signatures)
     uint8_t *data = signal_buffer_data(signature);
     size_t len = signal_buffer_len(signature);
 
-    result = curve_verify_signature(ec_key_pair_get_public(keys),
+    result = curve_verify_signature(global_context, ec_key_pair_get_public(keys),
             message, sizeof(message), data, len);
     ck_assert_int_eq(result, 1);
 
     data[0] ^= 0x01;
 
-    result = curve_verify_signature(ec_key_pair_get_public(keys),
+    result = curve_verify_signature(global_context, ec_key_pair_get_public(keys),
             message, sizeof(message), data, len);
     ck_assert_int_eq(result, 0);
 
@@ -394,7 +394,7 @@ START_TEST(test_unique_signatures)
                 signal_buffer_data(signature), signal_buffer_len(signature));
         ck_assert_int_eq(result, 0);
 
-        result = curve_verify_signature(
+        result = curve_verify_signature(global_context,
                 ec_key_pair_get_public(key_pair), message, i,
                 signal_buffer_data(signature), signal_buffer_len(signature));
         ck_assert_int_ne(result, 0);


### PR DESCRIPTION
This patch allows to use optional 3rd party curve25519 implementations usage. If any of the callbacks is missing, embedded implementation of curve25519-donna/ed25519 will be used for backward compatibility

Rationale behind: We are currently using wolfSSL curve25519/ed25519 APIs within our project and we would like to reuse this API and generated keys within libsignal as well. Unfortunately original implementation of signal doesn't allows that and is using non performance optimal nor standardized version of given algorithms including standardized testing vectors, which is already solved within 3rd party SSL implementations due to standardized usage of these algorithms within TLS/SSL.

This might bring incompatibility if one would use 3rd party implementation on TX size and tries to used it with embedded implementation on RX side. RX side might not decrypt the message correctly, so needs to be used with caution.

As we are not using any API from libsignal that in the end triggers the following APIs, this patch doesn't customize them:
* generalized_xeddsa_25519_sign
* generalized_xeddsa_25519_verify
* generalized_xveddsa_25519_sign
* generalized_xveddsa_25519_verify
