### PR TITLE
avoid cast size_t to int

### DIFF
--- a/src/device_consistency.c
+++ b/src/device_consistency.c
@@ -649,8 +649,10 @@ int device_consistency_signature_list_sort_comparator(const void *a, const void 
     if(len1 == len2) {
         result = memcmp(signal_buffer_data(buf1), signal_buffer_data(buf2), len1);
     }
-    else {
-        result = (int)(len1 - len2);
+    else if (len1 < len2) {
+        result = -1;
+    } else {
+        result = 1;
     }
 
     return result;


### PR DESCRIPTION
On platforms where size_t and int are different sizes, this cast converted an
unsigned value to a smaller signed value. This could change its interpretation
when the value being cast did not fit in an int. In practice, this is dead code
as the buffers being compared in this instance are always the same length.
However, this commit avoids future confusion or problems that may arise if usage
changes.

As discussed on the mailing list: https://lists.riseup.net/www/arc/whispersystems/2017-08/msg00001.html