### PR TITLE
Avoid including sys/cdefs.h header

### DIFF
--- a/src/vpool.h
+++ b/src/vpool.h
@@ -21,18 +21,6 @@
 #define _VPOOL_H_
 
 #include <sys/types.h>
-#if !defined(_WINDOWS) && !defined(__sun__)
-#include <sys/cdefs.h>
-#else
-#ifdef __cplusplus
-#define __BEGIN_DECLS extern "C" {
-#define __END_DECLS }
-#else
-#define __BEGIN_DECLS
-#define __END_DECLS
-#endif /* __cplusplus */
-#endif /* _WINDOWS */
-
 #include <limits.h>
 
 struct vpool {
@@ -48,8 +36,6 @@ struct vpool {
 
 enum vpool_trunc {VPOOL_EXCLUDE, VPOOL_INCLUDE};
 #define VPOOL_TAIL	UINT_MAX
-
-__BEGIN_DECLS
 
 void	vpool_init(struct vpool *pool, size_t blksize, size_t limit);
 void	vpool_final(struct vpool *pool);
@@ -70,7 +56,5 @@ int	vpool_truncate(struct vpool *pool,
 #define vpool_get_error(pool)		((pool)->v_lasterr)
 
 void	vpool_export(struct vpool *pool, void **buf, size_t *size);
-
-__END_DECLS
 
 #endif /* !_VPOOL_H_ */


### PR DESCRIPTION
sys/cdefs.h is non-standard, and other headers in the project already just use
`#ifdef __cplusplus` directly. The existing ifdefs and defines are confusing and
broken in some cases (for instance, musl libc does not provide sys/cdefs.h, so
the build fails).