### PR TITLE
Refactor cipher tests

### DIFF
--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
+    if(!message_data || !signature_data || signature_len != 96) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != 96) {
+    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/tests/test_group_cipher.c
+++ b/tests/test_group_cipher.c
@@ -63,13 +63,9 @@ START_TEST(test_no_session)
     signal_protocol_store_context *bob_store = 0;
     setup_test_store_context(&bob_store, global_context);
 
-    /* Create the session builders */
+    /* Create the session builder */
     group_session_builder *alice_session_builder = 0;
     result = group_session_builder_create(&alice_session_builder, alice_store, global_context);
-    ck_assert_int_eq(result, 0);
-
-    group_session_builder *bob_session_builder = 0;
-    result = group_session_builder_create(&bob_session_builder, bob_store, global_context);
     ck_assert_int_eq(result, 0);
 
     /* Create the group ciphers */
@@ -116,7 +112,6 @@ START_TEST(test_no_session)
     SIGNAL_UNREF(sent_alice_distribution_message);
     group_cipher_free(bob_group_cipher);
     group_cipher_free(alice_group_cipher);
-    group_session_builder_free(bob_session_builder);
     group_session_builder_free(alice_session_builder);
     signal_protocol_store_context_destroy(bob_store);
     signal_protocol_store_context_destroy(alice_store);

--- a/tests/test_group_cipher.c
+++ b/tests/test_group_cipher.c
@@ -336,7 +336,7 @@ START_TEST(test_late_join)
     signal_protocol_store_context *bob_store = 0;
     setup_test_store_context(&bob_store, global_context);
 
-    /* Create Alice's the session builder */
+    /* Create Alice's session builder */
     group_session_builder *alice_session_builder = 0;
     result = group_session_builder_create(&alice_session_builder, alice_store, global_context);
     ck_assert_int_eq(result, 0);

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -290,15 +290,8 @@ void run_interaction(session_record *alice_session_record, session_record *bob_s
     ck_assert_int_eq(result, 0);
 
     /* Have Bob decrypt the test message */
-    signal_buffer *bob_plaintext = 0;
-    result = session_cipher_decrypt_signal_message(bob_cipher, alice_message_deserialized, 0, &bob_plaintext);
-    ck_assert_int_eq(result, 0);
-
-    uint8_t *bob_plaintext_data = signal_buffer_data(bob_plaintext);
-    size_t bob_plaintext_len = signal_buffer_len(bob_plaintext);
-
-    ck_assert_int_eq(alice_plaintext_len, bob_plaintext_len);
-    ck_assert_int_eq(memcmp(alice_plaintext, bob_plaintext_data, bob_plaintext_len), 0);
+    signal_buffer *alice_plaintext_buffer = signal_buffer_create((uint8_t*) alice_plaintext, alice_plaintext_len);
+    decrypt_and_compare_messages(bob_cipher, alice_message_serialized, alice_plaintext_buffer);
 
     fprintf(stderr, "Interaction complete: Alice -> Bob\n");
 
@@ -389,7 +382,7 @@ void run_interaction(session_record *alice_session_record, session_record *bob_s
     SIGNAL_UNREF(alice_message_deserialized);
     SIGNAL_UNREF(reply_message_deserialized);
     signal_buffer_free(reply_plaintext);
-    signal_buffer_free(bob_plaintext);
+    signal_buffer_free(alice_plaintext_buffer);
     session_cipher_free(alice_cipher);
     session_cipher_free(bob_cipher);
     signal_protocol_store_context_destroy(alice_store);

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -257,18 +257,18 @@ void run_interaction(session_record *alice_session_record, session_record *bob_s
     setup_test_store_context(&bob_store, global_context);
 
     /* Store the two sessions in their data stores */
-    result = signal_protocol_session_store_session(alice_store, &alice_address, alice_session_record);
+    result = signal_protocol_session_store_session(alice_store, &bob_address, alice_session_record);
     ck_assert_int_eq(result, 0);
-    result = signal_protocol_session_store_session(bob_store, &bob_address, bob_session_record);
+    result = signal_protocol_session_store_session(bob_store, &alice_address, bob_session_record);
     ck_assert_int_eq(result, 0);
 
     /* Create two session cipher instances */
     session_cipher *alice_cipher = 0;
-    result = session_cipher_create(&alice_cipher, alice_store, &alice_address, global_context);
+    result = session_cipher_create(&alice_cipher, alice_store, &bob_address, global_context);
     ck_assert_int_eq(result, 0);
 
     session_cipher *bob_cipher = 0;
-    result = session_cipher_create(&bob_cipher, bob_store, &bob_address, global_context);
+    result = session_cipher_create(&bob_cipher, bob_store, &alice_address, global_context);
     ck_assert_int_eq(result, 0);
 
     /* Encrypt a test message from Alice */

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -132,11 +132,6 @@ void initialize_sessions_v3(session_state *alice_state, session_state *bob_state
     ec_key_pair *bob_ephemeral_key = bob_base_key;
     SIGNAL_REF(bob_base_key);
 
-    /* Generate Bob's pre-key */
-    ec_key_pair *bob_pre_key;
-    result = curve_generate_key_pair(global_context, &bob_pre_key);
-    ck_assert_int_eq(result, 0);
-
     /* Create Alice's parameters */
     alice_signal_protocol_parameters *alice_parameters = 0;
     result = alice_signal_protocol_parameters_create(&alice_parameters,
@@ -173,7 +168,6 @@ void initialize_sessions_v3(session_state *alice_state, session_state *bob_state
     SIGNAL_UNREF(bob_identity_key);
     SIGNAL_UNREF(bob_base_key);
     SIGNAL_UNREF(bob_ephemeral_key);
-    SIGNAL_UNREF(bob_pre_key);
     SIGNAL_UNREF(alice_parameters);
     SIGNAL_UNREF(bob_parameters);
 }

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -102,11 +102,6 @@ void initialize_sessions_v3(session_state *alice_state, session_state *bob_state
     result = curve_generate_key_pair(global_context, &alice_base_key);
     ck_assert_int_eq(result, 0);
 
-    /* Generate Alice's ephemeral key */
-    ec_key_pair *alice_ephemeral_key = 0;
-    result = curve_generate_key_pair(global_context, &alice_ephemeral_key);
-    ck_assert_int_eq(result, 0);
-
     /* Generate Alice's pre-key */
     ec_key_pair *alice_pre_key = alice_base_key;
     SIGNAL_REF(alice_base_key);
@@ -163,7 +158,6 @@ void initialize_sessions_v3(session_state *alice_state, session_state *bob_state
     /* Unref cleanup */
     SIGNAL_UNREF(alice_identity_key);
     SIGNAL_UNREF(alice_base_key);
-    SIGNAL_UNREF(alice_ephemeral_key);
     SIGNAL_UNREF(alice_pre_key);
     SIGNAL_UNREF(bob_identity_key);
     SIGNAL_UNREF(bob_base_key);

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -183,7 +183,7 @@ void generate_test_message_collections(session_cipher *cipher, signal_buffer **p
 
     int result = 0;
     int i;
-    for(i = 0; i < 50; i++) {
+    for(i = 0; i < size; i++) {
         /* Generate the plaintext */
         signal_buffer *plain_buf = signal_buffer_create(testMessage, sizeof(testMessage));
         uint8_t *plain_buf_data = signal_buffer_data(plain_buf);
@@ -207,9 +207,9 @@ void generate_test_message_collections(session_cipher *cipher, signal_buffer **p
     /* Randomize the two arrays using the same seed */
     time_t seed = time(0);
     srand(seed);
-    shuffle_buffers(plaintext_messages, 50);
+    shuffle_buffers(plaintext_messages, size);
     srand(seed);
-    shuffle_buffers(ciphertext_messages, 50);
+    shuffle_buffers(ciphertext_messages, size);
 }
 
 void decrypt_and_compare_messages(session_cipher *cipher, signal_buffer *ciphertext, signal_buffer *plaintext)


### PR DESCRIPTION
The group cipher and session cipher tests can be simplified:

### test_group_cipher
#### test_no_session()
- `bob_session_builder` is unused and can be removed

### test_session_cipher
#### initialize_sessions_v3()
- `alice_ephemeral_key` is unused and can be removed
- `bob_pre_key` is unused and can be removed
#### generate_test_message_collections()
- Use parameter `size` consistently (instead of `50`)
- Simplify code by calling `decrypt_and_compare_messages` (twice)
#### run_interaction()
- Switch `alice_address` and `bob_address` for consistency (Alice should initialize session for Bob's address)


