### PR TITLE
Use macro for fingerprint length, remove duplicate test code

### DIFF
--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
+    if(!message_data || !signature_data || signature_len != 96) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != 96) {
+    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/src/fingerprint.c
+++ b/src/fingerprint.c
@@ -8,7 +8,7 @@
 #include "vpool.h"
 
 #define FINGERPRINT_VERSION 0
-#define SHA512_DIGEST_LENGTH 64
+#define FINGERPRINT_LENGTH 30
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
@@ -349,7 +349,7 @@ int fingerprint_generator_get_fingerprint(fingerprint_generator *generator, sign
 
     len = signal_buffer_len(hash_buffer);
 
-    if(len < 30) {
+    if(len < FINGERPRINT_LENGTH) {
         result = SG_ERR_UNKNOWN;
         goto complete;
     }
@@ -382,18 +382,18 @@ int fingerprint_generator_create_display_string(fingerprint_generator *generator
     data = signal_buffer_data(fingerprint_buffer);
     len = signal_buffer_len(fingerprint_buffer);
 
-    if(len < 30) {
+    if(len < FINGERPRINT_LENGTH) {
         result = SG_ERR_UNKNOWN;
         goto complete;
     }
 
-    result_string = malloc(31);
+    result_string = malloc(FINGERPRINT_LENGTH+1);
     if(!result_string) {
         result = SG_ERR_NOMEM;
         goto complete;
     }
 
-    for(i = 0; i < 30; i += 5) {
+    for(i = 0; i < FINGERPRINT_LENGTH; i += 5) {
         uint64_t chunk = ((uint64_t)data[i] & 0xFFL) << 32 |
                 ((uint64_t)data[i + 1] & 0xFFL) << 24 |
                 ((uint64_t)data[i + 2] & 0xFFL) << 16 |

--- a/tests/test_fingerprint.c
+++ b/tests/test_fingerprint.c
@@ -202,14 +202,14 @@ static void test_vectors_impl(int version)
     scannable_fingerprint_serialize(&alice_buffer, alice_scannable);
     ck_assert_int_eq(result, 0);
 
+    scannable_fingerprint *bob_scannable = fingerprint_get_scannable(bob_fingerprint);
+    scannable_fingerprint_serialize(&bob_buffer, bob_scannable);
+    ck_assert_int_eq(result, 0);
+
     if(version == 0) {
         ck_assert_int_eq(signal_buffer_len(alice_buffer), sizeof(ALICE_SCANNABLE_FINGERPRINT_V0));
         ck_assert_int_eq(memcmp(signal_buffer_data(alice_buffer),
                 ALICE_SCANNABLE_FINGERPRINT_V0, sizeof(ALICE_SCANNABLE_FINGERPRINT_V0)), 0);
-
-        scannable_fingerprint *bob_scannable = fingerprint_get_scannable(bob_fingerprint);
-        scannable_fingerprint_serialize(&bob_buffer, bob_scannable);
-        ck_assert_int_eq(result, 0);
 
         ck_assert_int_eq(signal_buffer_len(bob_buffer), sizeof(BOB_SCANNABLE_FINGERPRINT_V0));
         ck_assert_int_eq(memcmp(signal_buffer_data(bob_buffer),
@@ -219,11 +219,7 @@ static void test_vectors_impl(int version)
         ck_assert_int_eq(signal_buffer_len(alice_buffer), sizeof(ALICE_SCANNABLE_FINGERPRINT_V1));
         ck_assert_int_eq(memcmp(signal_buffer_data(alice_buffer),
                 ALICE_SCANNABLE_FINGERPRINT_V1, sizeof(ALICE_SCANNABLE_FINGERPRINT_V1)), 0);
-
-        scannable_fingerprint *bob_scannable = fingerprint_get_scannable(bob_fingerprint);
-        scannable_fingerprint_serialize(&bob_buffer, bob_scannable);
-        ck_assert_int_eq(result, 0);
-
+        
         ck_assert_int_eq(signal_buffer_len(bob_buffer), sizeof(BOB_SCANNABLE_FINGERPRINT_V1));
         ck_assert_int_eq(memcmp(signal_buffer_data(bob_buffer),
                 BOB_SCANNABLE_FINGERPRINT_V1, sizeof(BOB_SCANNABLE_FINGERPRINT_V1)), 0);


### PR DESCRIPTION
Improvements for the `fingerprint.c` implementation:
- macro `SHA512_DIGEST_LENGTH` is unused and can be removed
- create macro `FINGERPRINT_LENGTH` and use it instead of the magic number `30`
Additionally:
- Remove duplicate code for `bob_scannable` in `test_fingerprint.c`