### PR TITLE
Remove unused sender chain keys from struct

### DIFF
--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
+    if(!message_data || !signature_data || signature_len != 96) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/src/curve.c
+++ b/src/curve.c
@@ -597,7 +597,7 @@ int curve_verify_vrf_signature(signal_context *context,
         return SG_ERR_INVAL;
     }
 
-    if(!message_data || !signature_data || signature_len != 96) {
+    if(!message_data || !signature_data || signature_len != VRF_SIGNATURE_LEN) {
         signal_log(context, SG_LOG_ERROR, "Invalid message or signature format");
         return SG_ERR_VRF_SIG_VERIF_FAILED;
     }

--- a/src/session_state.c
+++ b/src/session_state.c
@@ -24,7 +24,6 @@ typedef struct session_state_sender_chain
 {
     ec_key_pair *sender_ratchet_key_pair;
     ratchet_chain_key *chain_key;
-    message_keys_node *message_keys_head;
 } session_state_sender_chain;
 
 typedef struct session_state_receiver_chain
@@ -400,13 +399,6 @@ static int session_state_serialize_prepare_sender_chain(
 
     if(chain->chain_key) {
         result = session_state_serialize_prepare_chain_chain_key(chain->chain_key, chain_structure);
-        if(result < 0) {
-            goto complete;
-        }
-    }
-
-    if(chain->message_keys_head) {
-        result = session_state_serialize_prepare_chain_message_keys_list(chain->message_keys_head, chain_structure);
         if(result < 0) {
             goto complete;
         }
@@ -1789,17 +1781,6 @@ static void session_state_free_sender_chain(session_state *state)
     if(state->sender_chain.chain_key) {
         SIGNAL_UNREF(state->sender_chain.chain_key);
         state->sender_chain.chain_key = 0;
-    }
-
-    if(state->sender_chain.message_keys_head) {
-        message_keys_node *cur_node;
-        message_keys_node *tmp_node;
-        DL_FOREACH_SAFE(state->sender_chain.message_keys_head, cur_node, tmp_node) {
-            DL_DELETE(state->sender_chain.message_keys_head, cur_node);
-            signal_explicit_bzero(&cur_node->message_key, sizeof(ratchet_message_keys));
-            free(cur_node);
-        }
-        state->sender_chain.message_keys_head = 0;
     }
 }
 


### PR DESCRIPTION
The `message_keys_head` variable of the `session_state_sender_chain` is unused and can be removed:

There is no reason to store any message keys for the sender chain, since message keys are used by the receiver chain to decrypt out of order messages. This can't happen for the sender chain.

Currently, the `message_keys_head` variable is only used for serializing the sender chain, and the keys aren't even recovered when deserializing.

As always: All tests are still passing.