### PR TITLE
Add wolfSSL support for test programs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ environments. See the [Java library](https://github.com/whispersystems/libsignal
 * [Check *1](https://libcheck.github.io/check/)
 * [OpenSSL *1](https://www.openssl.org/) 1.0 or higher
  * On MacOS X, [Common Crypto](https://developer.apple.com/library/content/documentation/Security/Conceptual/cryptoservices/GeneralPurposeCrypto/GeneralPurposeCrypto.html) is used instead of OpenSSL
+ * You can choose [WolfSSL](https://github.com/wolfSSL/wolfssl/releases) (3.13.0 or higher) instead of OpenSSL
 * [LCOV *2](http://ltp.sourceforge.net/coverage/lcov.php)
 
 Most of these dependencies are required just for the unit test suite and
@@ -29,7 +30,7 @@ Items marked with *1 are required for tests, with *2 are additionally required f
     $ cmake -DCMAKE_BUILD_TYPE=Debug ..
     $ make
 
-### Running the unit tests
+### Running the unit tests with OpenSSL
 
     $ cd /path/to/libsignal-protocol-c/build
     $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=1 ..
@@ -38,6 +39,17 @@ Items marked with *1 are required for tests, with *2 are additionally required f
     $ cd ..
     $ ctest
 
+### Running the unit tests with WolfSSL
+Note: You need to build wolfssl library with these configure options.  
+    $ configure --enable-opensslextra --enable-signal
+  
+    $ cd /path/to/libsignal-protocol-c/build
+    $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=1 -DWOLFSSL=<wolfssl installed directory> ..
+    $ cd tests
+    $ make
+    $ cd ..
+    $ ctest
+    
 ### Creating the code coverage report
 
     $ cd /path/to/libsignal-protocol-c/build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,11 @@ enable_testing()
 find_library(M_LIB m)
 find_package(Check REQUIRED)
 IF(NOT(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
-  find_package(OpenSSL 1.0 REQUIRED)
+  IF(WOLFSSL)
+    find_library(WOLFSSL_LIB wolfssl)
+  ELSE()
+    find_package(OpenSSL 1.0 REQUIRED)
+  ENDIF()
 ENDIF()
 find_package(Threads)
 include_directories(${CHECK_INCLUDE_DIRS})
@@ -30,14 +34,27 @@ else()
   set(TEST_PATH ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-set(LIBS ${LIBS}
-	${M_LIB}
-	${CHECK_LDFLAGS}
-	${OPENSSL_LIBRARIES}
-	${CMAKE_THREAD_LIBS_INIT}
-	${CMAKE_DL_LIBS}
-	signal-protocol-c
-)
+# set(WOLFSSL_LIBRARIES "-L/usr/local/lib -lwolfssl")
+
+IF (WOLFSSL)
+  set(LIBS ${LIBS}
+    ${M_LIB}
+    ${CHECK_LDFLAGS}
+    ${WOLFSSL_LIB}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+    signal-protocol-c
+  )
+ELSE ()
+  set(LIBS ${LIBS}
+    ${M_LIB}
+    ${CHECK_LDFLAGS}
+    ${OPENSSL_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+    signal-protocol-c
+  )
+ENDIF()
 
 set(common_SRCS
 	test_common.c
@@ -45,7 +62,6 @@ set(common_SRCS
 )
 
 include_directories(. ../src)
-
 IF(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set(common_SRCS ${common_SRCS}
 		test_common_ccrypto.c
@@ -54,7 +70,12 @@ ELSE()
 	set(common_SRCS ${common_SRCS}
 		test_common_openssl.c
 	)
-	include_directories(${OPENSSL_INCLUDE_DIR})
+  IF(WOLFSSL)
+    include_directories(${WOLFSSL}/include/wolfssl)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-conversion -include ${WOLFSSL}/include/wolfssl/options.h")
+  ELSE(WOLFSSL)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+  ENDIF(WOLFSSL)
 ENDIF()
 
 add_executable(test_curve25519 test_curve25519.c ${common_SRCS})


### PR DESCRIPTION
I added cmake configuration to build test programs with wolfSSL.
And I also fixed wolfSSL library code to be able to compile tests with libsignal-protocol-c.
My fixes is included in wolfSSL 3.13.0.